### PR TITLE
py2 compat: Do not catch py3 only exception

### DIFF
--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -176,13 +176,12 @@ def connected_socket(path):
         unix_socket.connect(path)
         unix_socket.send(six.b('show info' + '\n'))
         file_handle = unix_socket.makefile()
-    except (ConnectionRefusedError, PermissionError, socket.timeout, OSError):
+    except (socket.timeout, OSError):
         return False
     else:
         try:
             data = file_handle.read().splitlines()
-        except (ConnectionResetError, ConnectionRefusedError, PermissionError,
-                socket.timeout, OSError):
+        except (socket.timeout, OSError):
             return False
         else:
             hap_info = info2dict(data)


### PR DESCRIPTION
`Connection*Error` and `PermissionError` are subclasses of OSError so no
need to be overly specific.
