### PR TITLE
Fix problem with unknown exceptions for Python 2

### DIFF
--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -22,7 +22,7 @@ from haproxyadmin.command_status import (ERROR_OUTPUT_STRINGS,
 
 try:
     EXCEPT_LIST = (ConnectionRefusedError, PermissionError, socket.timeout, OSError)
-    EXCEPT_RESET_LIST = tuple([ConnectionResetError].extend(EXCEPT_LIST))
+    EXCEPT_RESET_LIST = tuple([ConnectionResetError] + EXCEPT_LIST)
 except:
     EXCEPT_RESET_LIST = EXCEPT_LIST = (socket.error, socket.timeout, OSError)
     


### PR DESCRIPTION
Since there's a problem with ConnectionRefusedError, ConnectionResetError, etc. in Python 2 this patch improves this support, allowing the haproxyadmin to be usable in version 2.