### PR TITLE
Allow use of tcp socket to connect to haproxy stats

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
+Ori Shoshan <ori.shoshan@guardicore.com>
 Pavlos Parissis <pavlos.parissis@booking.com>
 Pavlos Parissis <pavlos.parissis@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+* Added setaddress and address to Servers
+* Fix docstrings
+* Remove unused variables
+* Ignore Python 3 class hierarchy of OSError errors
+* Update installation instructions
+
 0.2.1
 -----
 
@@ -74,7 +80,7 @@ CHANGES
 * fix a regression introduced with dcc5173e31deac
 * add support for sending commands to haproxy
 * simplify the way we send commands to socket
-* add support for keyword arguments in cmd_across_all_procs()
+* add support for keyword arguments in cmd\_across\_all\_procs()
 * fix (once again) format issues in TODO.rst
 * fix format issues in TODO.rst
 * add some ordering in our TODO items
@@ -117,7 +123,7 @@ CHANGES
 * internal.py: OSError exception doesn't have message attribute
 * remove unnecessary declaration
 * don't use relative imports as our module layout is quit flat and very short
-* __init__.py:add version and remove ascii art
+* \_\_init\_\_.py:add version and remove ascii art
 * import all exceptions in the doc rather import each one individually
 * exceptions.py: use correct exception names
 * add SocketTimeout exception and raise it when we got timeout after X retries
@@ -139,8 +145,8 @@ CHANGES
 -----
 
 * RELEASE 0.1.0 version
-* raise CommandFailed rather ValueError in show_acl
-* show_acl: rename acl argument to aclid to be consistent with show_map
+* raise CommandFailed rather ValueError in show\_acl
+* show\_acl: rename acl argument to aclid to be consistent with show\_map
 * update TODO
 * update docstring for acl commands
 
@@ -162,7 +168,7 @@ CHANGES
 * tiny reformatting on exceptions
 * haproxy.py: explicitly check for the existence of socket directory
 * Update TODO
-* extend ERROR_OUTPUT_STRINGS to support address field
+* extend ERROR\_OUTPUT\_STRINGS to support address field
 * include Socket family exceptions in the documentation
 * updates on ChangeLog
 
@@ -173,7 +179,7 @@ CHANGES
 * haproxy.py: reformating
 * utils.py: raise an appropriate exception when we check for valid socket files
 * add a bunch of exceptions for catching errors when we test socket file
-* connected_socket() perform a sanity on the date returned
+* connected\_socket() perform a sanity on the date returned
 
 0.0.4
 -----
@@ -182,7 +188,7 @@ CHANGES
 * update TODO
 * haproxy.py: fix a bug in add map where we forgot to set value
 * haproxy.py: ignore socket files not bound to a process
-* utils.py: add connected_socket to check if a socket is bound to a process
+* utils.py: add connected\_socket to check if a socket is bound to a process
 * include six and not docopt in requirements.txt
 * add requirements file for pip installations
 * bump version on docs as well
@@ -195,7 +201,7 @@ CHANGES
 
 * RELEASE 0.0.3 version
 * DOC: another set of updates
-* rename get_frontends to frontends
+* rename get\_frontends to frontends
 * Performance improvements due to the way we interact with stats socket
 * update haproxy.cfg, give a unique name for each listen directive
 * Update TODO.rst
@@ -208,7 +214,7 @@ CHANGES
 * DOC: add remaining examples for frontends in User Guide
 * README: add missing variable
 * DOC: add examples for backends in User Guide
-* backend.py: remove status from BACKEND_METRICS
+* backend.py: remove status from BACKEND\_METRICS
 * DOC: add a bunch of examples for frontends in User Guide
 * DOC: add missing example code
 * DOC: add more examples for HAProxy operations in the User Guide
@@ -231,7 +237,7 @@ CHANGES
 * RELEASE 0.0.2 version
 * README: merged TODO into README
 * README: documention reference doesn't need to be a section
-* internal.py: wrong refactoring for _Backend class
+* internal.py: wrong refactoring for \_Backend class
 * refactor Pool to backend
 * refactor PoolMember to Server
 * major updates on docstrings to allow sphinx integration
@@ -241,7 +247,7 @@ CHANGES
 * utils.py update docstrings
 * TODO: work in progress for updating docstrings
 * internal.py: update docstrings
-* internal.py: change parameter name to name for get_frontends
+* internal.py: change parameter name to name for get\_frontends
 * merged NOTES into TODO
 * NOTES: tiny fix
 * add some notes
@@ -251,12 +257,12 @@ CHANGES
 * haproxy.py: fix typo
 * We don't need it anymore and it was a bad idea
 * add haproxy.cfg which we use
-* utils.py: we don't perform any calculation for Uptime_sec field
+* utils.py: we don't perform any calculation for Uptime\_sec field
 * haproxy.py: docstring fix
 * haproxy.py: add a bunch of properties for HAProxy process
 * utils.py don't remove trailing whitespace when parse 'show info' output
 * haproxy.py: perform calculation in metric() if the caller wants it
-* internal.py remove unused function run_commandold
+* internal.py remove unused function run\_commandold
 * change license to Apache 2.0
 * README.rst: add acknowledgement section
 * switch to README.rst by removing README.md

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* Allow use of tcp socket to connect to haproxy stats
 * Added setaddress and address to Servers
 * Fix docstrings
 * Remove unused variables

--- a/haproxyadmin/haproxy.py
+++ b/haproxyadmin/haproxy.py
@@ -12,6 +12,8 @@ This module implements the main haproxyadmin API.
 import os
 import glob
 
+from urlparse import urlparse
+
 from haproxyadmin.frontend import Frontend
 from haproxyadmin.backend import Backend
 from haproxyadmin.utils import (is_unix_socket, cmd_across_all_procs, converter,
@@ -95,11 +97,12 @@ class HAProxy(object):
 
     def __init__(self, socket_dir=None,
                  socket_file=None,
+		 uris=None,
                  retry=2,
                  retry_interval=2):
 
         self._hap_processes = []
-        socket_files = []
+        sockets = []
 
         if socket_dir:
             if not os.path.exists(socket_dir):
@@ -112,16 +115,21 @@ class HAProxy(object):
         elif (socket_file and is_unix_socket(socket_file) and
               connected_socket(socket_file)):
             socket_files.append(os.path.realpath(socket_file))
+	elif (uris):
+	    uriarr = uris.split(",")
+	    for uri in uriarr:
+		print uri
+                sockets.append(uri)
         else:
             raise ValueError("UNIX socket file was not set")
 
-        if not socket_files:
+        if not sockets:
             raise ValueError("No valid UNIX socket file was found, directory: "
                              "{} file: {}".format(socket_dir, socket_file))
 
-        for so_file in socket_files:
+        for sock in sockets:
             self._hap_processes.append(
-                _HAProxyProcess(so_file, retry, retry_interval)
+                _HAProxyProcess(sock, retry, retry_interval)
             )
 
     @should_die

--- a/haproxyadmin/haproxy.py
+++ b/haproxyadmin/haproxy.py
@@ -118,7 +118,6 @@ class HAProxy(object):
 	elif (uris):
 	    uriarr = uris.split(",")
 	    for uri in uriarr:
-		print uri
                 sockets.append(uri)
         else:
             raise ValueError("UNIX socket file was not set")

--- a/haproxyadmin/haproxy.py
+++ b/haproxyadmin/haproxy.py
@@ -12,7 +12,10 @@ This module implements the main haproxyadmin API.
 import os
 import glob
 
-from urlparse import urlparse
+from future.standard_library import install_aliases
+install_aliases()
+
+from urllib.parse import urlparse
 
 from haproxyadmin.frontend import Frontend
 from haproxyadmin.backend import Backend
@@ -97,7 +100,7 @@ class HAProxy(object):
 
     def __init__(self, socket_dir=None,
                  socket_file=None,
-		 uris=None,
+                 uris=None,
                  retry=2,
                  retry_interval=2):
 
@@ -115,9 +118,10 @@ class HAProxy(object):
         elif (socket_file and is_unix_socket(socket_file) and
               connected_socket(socket_file)):
             socket_files.append(os.path.realpath(socket_file))
-	elif (uris):
-	    uriarr = uris.split(",")
-	    for uri in uriarr:
+
+        elif uris:
+            uriarr = uris.split(",")
+            for uri in uriarr:
                 sockets.append(uri)
         else:
             raise ValueError("UNIX socket file was not set")

--- a/haproxyadmin/internal.py
+++ b/haproxyadmin/internal.py
@@ -73,29 +73,29 @@ class _HAProxyProcess(object):
             attempt = self.retry + 1
         while attempt != 0:
             try:
-		unix_socket = None;
-		tcpsocket = None;
-		if is_unix_socket(self.sock):
-		    unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                unix_socket = None
+                tcpsocket = None
+                if is_unix_socket(self.sock):
+                    unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                     unix_socket.settimeout(0.5)
                     unix_socket.connect(self.sock)
                     unix_socket.send(six.b(command + '\n'))
                     file_handle = unix_socket.makefile()
                     data = file_handle.read().splitlines()
 
-		else:
-		    tcpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		    parts = urisplit(self.sock)
-    		    if type(parts.gethost()) == ipaddress.IPv4Address or hostname_resolves(parts.gethost()):
-			tcpsocket.settimeout(2.0)
+                else:
+                    tcpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    parts = urisplit(self.sock)
+                    if type(parts.gethost()) == ipaddress.IPv4Address or hostname_resolves(parts.gethost()):
+                        tcpsocket.settimeout(2.0)
                         tcpsocket.connect((parts.gethost(), parts.getport()))
                         tcpsocket.send(six.b(command + '\n'))
                         file_handle = tcpsocket.makefile()
                         data = file_handle.read().splitlines()
-		    else:
-			raise ValueError("URI is neither a valid IPAddess nor a resolvable hostname")
-			
-			
+                    else:
+                        raise ValueError("URI is neither a valid IPAddess nor a resolvable hostname")
+
+
                 # I haven't seen a case where a running process which holds a
                 # UNIX socket will take more than few nanoseconds to accept a
                 # connection. But, I have seen cases where it takes ~0.5secs
@@ -129,10 +129,10 @@ class _HAProxyProcess(object):
                 # get out from the retry loop
                 break
             finally:
-		if unix_socket:
+                if unix_socket:
                     unix_socket.close()
-		elif tcpsocket:
-		    tcpsocket.close()
+                elif tcpsocket:
+                    tcpsocket.close()
                 if raised:
                     time.sleep(self.retry_interval)
 

--- a/haproxyadmin/internal.py
+++ b/haproxyadmin/internal.py
@@ -87,7 +87,7 @@ class _HAProxyProcess(object):
 		    tcpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		    parts = urisplit(self.sock)
     		    if type(parts.gethost()) == ipaddress.IPv4Address or hostname_resolves(parts.gethost()):
-			tcpsocket.settimeout(0.5)
+			tcpsocket.settimeout(2.0)
                         tcpsocket.connect((parts.gethost(), parts.getport()))
                         tcpsocket.send(six.b(command + '\n'))
                         file_handle = tcpsocket.makefile()

--- a/haproxyadmin/internal.py
+++ b/haproxyadmin/internal.py
@@ -16,8 +16,9 @@ import socket
 import errno
 import time
 import six
-
-from haproxyadmin.utils import (info2dict, stat2dict)
+from uritools import urisplit
+import ipaddress
+from haproxyadmin.utils import (info2dict, stat2dict, is_unix_socket, hostname_resolves)
 from haproxyadmin.exceptions import (SocketTransportError, SocketTimeout,
                                      SocketConnectionError)
 
@@ -28,16 +29,16 @@ class _HAProxyProcess(object):
     It acts as a communication pipe between the caller and individual
     HAProxy process using UNIX stats socket.
 
-    :param socket_file: Full path of socket file.
-    :type socket_file: string
+    :param sock: Full path of socket file or tcp socket
+    :type sock: string
     :param retry: (optional) Number of connect retries (defaults to 3)
     :type retry: integer
     :param retry_interval: (optional) Interval time in seconds between retries
                            (defaults to 2)
     :type retry_interval: integer
     """
-    def __init__(self, socket_file, retry=3, retry_interval=2):
-        self.socket_file = socket_file
+    def __init__(self, sock, retry=3, retry_interval=2):
+        self.sock = sock
         self.hap_stats = {}
         self.hap_info = {}
         self.retry = retry
@@ -72,29 +73,46 @@ class _HAProxyProcess(object):
             attempt = self.retry + 1
         while attempt != 0:
             try:
-                unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		unix_socket = None;
+		tcpsocket = None;
+		if is_unix_socket(self.sock):
+		    unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    unix_socket.settimeout(0.5)
+                    unix_socket.connect(self.sock)
+                    unix_socket.send(six.b(command + '\n'))
+                    file_handle = unix_socket.makefile()
+                    data = file_handle.read().splitlines()
+
+		else:
+		    tcpsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		    parts = urisplit(self.sock)
+    		    if type(parts.gethost()) == ipaddress.IPv4Address or hostname_resolves(parts.gethost()):
+			tcpsocket.settimeout(0.5)
+                        tcpsocket.connect((parts.gethost(), parts.getport()))
+                        tcpsocket.send(six.b(command + '\n'))
+                        file_handle = tcpsocket.makefile()
+                        data = file_handle.read().splitlines()
+		    else:
+			raise ValueError("URI is neither a valid IPAddess nor a resolvable hostname")
+			
+			
                 # I haven't seen a case where a running process which holds a
                 # UNIX socket will take more than few nanoseconds to accept a
                 # connection. But, I have seen cases where it takes ~0.5secs
                 # to get a respone from the socket. Thus I hard-code a timeout
                 # of 0.5ms
                 # TODO: consider having a configuration file for it
-                unix_socket.settimeout(0.5)
-                unix_socket.connect(self.socket_file)
-                unix_socket.send(six.b(command + '\n'))
-                file_handle = unix_socket.makefile()
-                data = file_handle.read().splitlines()
             except socket.timeout:
-                raised = SocketTimeout(socket_file=self.socket_file)
+                raised = SocketTimeout(sock=self.sock)
             except OSError as exc:
                 # while stress testing HAProxy and querying for all frontend
                 # metrics I sometimes get:
                 # OSError: [Errno 106] Transport endpoint is already connected
                 # catch this one only and reraise it withour exception
                 if exc.errno == errno.EISCONN:
-                    raised = SocketTransportError(socket_file=self.socket_file)
+                    raised = SocketTransportError(sock=self.sock)
                 elif exc.errno == errno.ECONNREFUSED:
-                    raised = SocketConnectionError(self.socket_file)
+                    raised = SocketConnectionError(self.sock)
                 else:
                     # for the rest of OSError exceptions just reraise them
                     raised = exc
@@ -111,7 +129,10 @@ class _HAProxyProcess(object):
                 # get out from the retry loop
                 break
             finally:
-                unix_socket.close()
+		if unix_socket:
+                    unix_socket.close()
+		elif tcpsocket:
+		    tcpsocket.close()
                 if raised:
                     time.sleep(self.retry_interval)
 

--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -9,16 +9,16 @@ haproxyadmin.
 
 """
 
-import socket
 import os
+import socket
 import stat
 from functools import wraps
-import six
 
-from haproxyadmin.exceptions import (CommandFailed, MultipleCommandResults,
-                                     IncosistentData)
+import six
 from haproxyadmin.command_status import (ERROR_OUTPUT_STRINGS,
                                          SUCCESS_OUTPUT_STRINGS)
+from haproxyadmin.exceptions import (CommandFailed, MultipleCommandResults,
+                                     IncosistentData)
 
 METRICS_SUM = [
     'CompressBpsIn',
@@ -126,11 +126,12 @@ def should_die(old_implementation):
     ``False`` it returns ``True`` if decorated function run successfully or
     ``False`` if an exception was raised.
     """
+
     @wraps(old_implementation)
     def new_implementation(*args, **kwargs):
         try:
             die = kwargs['die']
-            del(kwargs['die'])
+            del (kwargs['die'])
         except KeyError:
             die = True
 
@@ -145,12 +146,14 @@ def should_die(old_implementation):
 
     return new_implementation
 
+
 def hostname_resolves(hostname):
     try:
         socket.gethostbyname(hostname)
         return True
     except socket.error:
         return False
+
 
 def is_unix_socket(path):
     """Return ``True`` if path is a valid UNIX socket otherwise False.
@@ -161,13 +164,14 @@ def is_unix_socket(path):
     """
     issock = None
     try:
-      mode = os.stat(path).st_mode
-      issock = S_ISSOCK(mode)
+        mode = os.stat(path).st_mode
+        issock = S_ISSOCK(mode)
 
     except Exception as e:
         return False
     else:
-      return issock
+        return issock
+
 
 def connected_socket(path):
     """Check if socket file is a valid HAProxy socket file.
@@ -354,11 +358,12 @@ def calculate(name, metrics):
     if name in METRICS_SUM:
         return sum(metrics)
     elif name in METRICS_AVG:
-        return int(sum(metrics)/len(metrics))
+        return int(sum(metrics) / len(metrics))
     else:
         # This is to catch the case where the caller forgets to check if
         # metric name is a valide metric for HAProxy.
         raise ValueError("Unknown type of calculation for {}".format(name))
+
 
 def isint(value):
     """Check if input can be converted to an integer
@@ -374,6 +379,7 @@ def isint(value):
         return True
     except ValueError:
         return False
+
 
 def converter(value):
     """Tries to convert input value to an integer.

--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -145,6 +145,12 @@ def should_die(old_implementation):
 
     return new_implementation
 
+def hostname_resolves(hostname):
+    try:
+        socket.gethostbyname(hostname)
+        return True
+    except socket.error:
+        return False
 
 def is_unix_socket(path):
     """Return ``True`` if path is a valid UNIX socket otherwise False.
@@ -153,9 +159,15 @@ def is_unix_socket(path):
     :type path: ``string``
     :rtype: ``bool``
     """
-    mode = os.stat(path).st_mode
+    issock = None
+    try:
+      mode = os.stat(path).st_mode
+      issock = S_ISSOCK(mode)
 
-    return stat.S_ISSOCK(mode)
+    except Exception, e:
+      return False
+    else:
+      return issock
 
 def connected_socket(path):
     """Check if socket file is a valid HAProxy socket file.

--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -164,8 +164,8 @@ def is_unix_socket(path):
       mode = os.stat(path).st_mode
       issock = S_ISSOCK(mode)
 
-    except Exception, e:
-      return False
+    except Exception as e:
+        return False
     else:
       return issock
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+uritools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+future
 six
 uritools

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
         Programming Language :: Python :: 3.4
         Topic :: Utilities
 requires-dist =
+    future
     six
     psutil
     uritools

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifier =
 requires-dist =
     six
     psutil
+    uritools
 keywords =
     haproxy
 

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr'],
-    install_requires=['uritools'],
+    install_requires=['uritools','future'],
     pbr=True)

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr'],
+    install_requires=['uritools'],
     pbr=True)


### PR DESCRIPTION
This may need some testing and finishing touches, as i am not that familiar with python.

This is my haproxy config part for the tcp socket
```
stats socket ipv4@*:5555 level admin
stats timeout 2m
```

