### PR TITLE
Set server port as well as address, add doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,20 @@ for various statistics provided by HAProxy. For instance, to report the
 requests processed by a frontend it queries all processes which manage that
 frontend and return the sum.
 
+To make this possible, haproxy need to expose a stat socket for every process.
+This is accomplished by defining a number of uniquely named stat sockets 
+in 'global' equal to nbproc and attaching them to a dedicated process each:
+
+.. code-block:: 
+
+   global
+      nbproc 4
+      stats socket /run/haproxy/1.sock mode 600 level admin process 1
+      stats socket /run/haproxy/2.sock mode 600 level admin process 2
+      stats socket /run/haproxy/3.sock mode 600 level admin process 3
+      stats socket /run/haproxy/4.sock mode 600 level admin process 4
+
+
 The library works with Python 2.7 and Python 3.4, but for development and
 testing Python 3.4 is used. The `Six Python 2 and 3 Compatibility Library`_
 is being used to provide the necessary wrapping over the differences between

--- a/haproxyadmin/internal.py
+++ b/haproxyadmin/internal.py
@@ -515,13 +515,25 @@ class _Server(object):
 
     @property
     def address(self):
-        """
-        Return server address
+        """Return server address
+
+        :rtype: ``string``
         """
         data = self.stats_data()
         return data.addr
 
-    def setaddress(self, new_address):
+    def setaddress(self, new_address, new_port=None):
+        """Set server ip and port
+
+        :param new_address: new ip address of server
+        :param new_port: new port of server (optional)
+        :return:
+        """
+
+        if new_port:
+            return self.command("set server {be}/{srv} addr {new_address} port {new_port}".format(
+                be=self.backend.name, srv=self._name, new_address=new_address, new_port=new_port))
+
         return self.command("set server {be}/{srv} addr {new_address}".format(
             be=self.backend.name, srv=self._name, new_address=new_address))
 

--- a/haproxyadmin/server.py
+++ b/haproxyadmin/server.py
@@ -131,16 +131,23 @@ class Server(object):
 
     @property
     def address(self):
+        """Return server ip and port
+
+        :rtype: ``string``
+        """
         return self._server_per_proc[0].address
 
-    def setaddress(self, new_address):
-        """
-        Set this server's address.
+    def setaddress(self, new_address, new_port=None):
+        """Set this servers address.
+
+        :param new_address: new ip address of server
+        :param new_port: new port of server (optional)
+
         :rtype: ``string``
         """
 
         values = cmd_across_all_procs(
-            self._server_per_proc, 'setaddress', new_address=str(new_address)
+            self._server_per_proc, 'setaddress', new_address=str(new_address), new_port=new_port
         )
 
         return compare_values(values)


### PR DESCRIPTION
I've added the ability to change the port of a backend server as well.
I reused the method '.setaddress()', as '.address' returns ip and port anyway. 

Tested with Haproxy 1.8.7 

And I fixed the docstrings of both methods and added a small example the the readme to clarify how to use it with nbproc > 1. 