### PR TITLE
Add support for slim metric to Server object

### DIFF
--- a/haproxyadmin/server.py
+++ b/haproxyadmin/server.py
@@ -57,6 +57,7 @@ SERVER_METRICS = [
     'rate_max',
     'rtime',
     'scur',
+    'slim',
     'smax',
     'srv_abrt',
     'stot',


### PR DESCRIPTION
Servers have their own session limit. This is currently missing in the Servers object metric list.