### PR TITLE
connected_socket(): fix validation check for HAPEE >= 2.1

### DIFF
--- a/haproxyadmin/utils.py
+++ b/haproxyadmin/utils.py
@@ -190,7 +190,7 @@ def connected_socket(path):
         unix_socket.close()
 
     try:
-        return hap_info['Name'] == 'HAProxy'
+        return hap_info['Name'] in ['HAProxy', 'hapee-lb']
     except KeyError:
         return False
 


### PR DESCRIPTION
The command `socket info` returns metadata about the socket
connection to a HAProxy process. Since the latest release of
HAProxy Enterprise Edition (2.1), the `Name` entry is no longer
"HAProxy" but "hapee-lb". This broke our validation check,
causing connected_socket() to always return False.